### PR TITLE
Kafka Producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,11 @@ By other hand, port 29092 of kafka service is now exposed to listening from loca
 ### [Fix: change in project description](https://github.com/atromilen/spring-kafka-producer/pull/3/files)
 Changed project description to **producer** instad of consumer. Added in README, detail of docker services managed by 
 docker-compose.
+
+### [Kafka Producer implementation](https://github.com/atromilen/spring-kafka-producer/pull/4)
+- Implementation of the Controller to receive messages to be sent to Kafka via the Service class
+- Integrated test for service layer. <br/>
+- Properties handling was encapsulated into the new class **ConfigProperties**, in order to inject it when it will be 
+necessary. <br/>
+- Added test profile to separate properties for embedded kafka broker in test scope. <br/>
+- Improved the documentation about the kafka properties specified in application.yml adding a new **MANIFEST-INFO** json file.

--- a/build.gradle
+++ b/build.gradle
@@ -19,14 +19,22 @@ repositories {
 }
 
 dependencies {
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.kafka:spring-kafka'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.named('compileJava') {
+	inputs.files(tasks.named('processResources'))
 }

--- a/src/main/java/cl/atromilen/springkafkaproducer/config/ConfigProperties.java
+++ b/src/main/java/cl/atromilen/springkafkaproducer/config/ConfigProperties.java
@@ -1,0 +1,15 @@
+package cl.atromilen.springkafkaproducer.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "spring.kafka")
+@Data
+public class ConfigProperties {
+    private String bootstrapServers;
+    private String topicName;
+    private Integer topicPartitions;
+    private Integer topicReplicas;
+}

--- a/src/main/java/cl/atromilen/springkafkaproducer/config/KafkaProducerConfig.java
+++ b/src/main/java/cl/atromilen/springkafkaproducer/config/KafkaProducerConfig.java
@@ -1,0 +1,40 @@
+package cl.atromilen.springkafkaproducer.config;
+
+import cl.atromilen.springkafkaproducer.event.Event;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    private ConfigProperties configProperties;
+
+    public KafkaProducerConfig(ConfigProperties configProperties) {
+        this.configProperties = configProperties;
+    }
+
+    @Bean
+    public ProducerFactory<String, Event<?>> producerFactory(){
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, configProperties.getBootstrapServers());
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Event<?>> kafkaTemplate(){
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/src/main/java/cl/atromilen/springkafkaproducer/config/KafkaTopicConfiguration.java
+++ b/src/main/java/cl/atromilen/springkafkaproducer/config/KafkaTopicConfiguration.java
@@ -2,7 +2,6 @@ package cl.atromilen.springkafkaproducer.config;
 
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
@@ -14,32 +13,26 @@ import java.util.Map;
 @Configuration
 public class KafkaTopicConfiguration {
 
-    @Value(value = "${spring.kafka.bootstrap-servers}")
-    private String bootstrapAddress;
+    private ConfigProperties configProperties;
 
-    @Value(value = "${spring.kafka.topic-name}")
-    private String topicName;
-
-    @Value(value = "${spring.kafka.topic-partitions}")
-    private Integer topicPartitions;
-
-    @Value(value = "${spring.kafka.topic-replicas}")
-    private Integer topicReplicas;
+    public KafkaTopicConfiguration(ConfigProperties configProperties) {
+        this.configProperties = configProperties;
+    }
 
     @Bean
-    public KafkaAdmin kafkaAdmin(){
+    public KafkaAdmin kafkaAdmin() {
         Map<String, Object> configs = new HashMap<>();
-        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, configProperties.getBootstrapServers());
 
         return new KafkaAdmin(configs);
     }
 
     @Bean
-    public NewTopic newTopic(){
+    public NewTopic newTopic() {
         return TopicBuilder
-                .name(topicName)
-                .partitions(topicPartitions)
-                .replicas(topicReplicas)
+                .name(configProperties.getTopicName())
+                .partitions(configProperties.getTopicPartitions())
+                .replicas(configProperties.getTopicReplicas())
                 .build();
     }
 

--- a/src/main/java/cl/atromilen/springkafkaproducer/controller/MessageController.java
+++ b/src/main/java/cl/atromilen/springkafkaproducer/controller/MessageController.java
@@ -1,0 +1,25 @@
+package cl.atromilen.springkafkaproducer.controller;
+
+import cl.atromilen.springkafkaproducer.event.MessageForEmailing;
+import cl.atromilen.springkafkaproducer.service.KafkaProducerService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController()
+@RequestMapping("/messages")
+public class MessageController {
+
+    private KafkaProducerService producerService;
+
+    public MessageController(KafkaProducerService producerService) {
+        this.producerService = producerService;
+    }
+
+    @PostMapping("/save")
+    public void saveMessage(@RequestBody MessageForEmailing message){
+        producerService.send(message);
+    }
+
+}

--- a/src/main/java/cl/atromilen/springkafkaproducer/event/Event.java
+++ b/src/main/java/cl/atromilen/springkafkaproducer/event/Event.java
@@ -1,0 +1,11 @@
+package cl.atromilen.springkafkaproducer.event;
+
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+public class Event<T> {
+    private final Instant date = Instant.now();
+    private T data;
+}

--- a/src/main/java/cl/atromilen/springkafkaproducer/event/MessageForEmailing.java
+++ b/src/main/java/cl/atromilen/springkafkaproducer/event/MessageForEmailing.java
@@ -1,0 +1,9 @@
+package cl.atromilen.springkafkaproducer.event;
+
+import lombok.Data;
+
+@Data
+public class MessageForEmailing {
+    private String email;
+    private String messageBody;
+}

--- a/src/main/java/cl/atromilen/springkafkaproducer/service/KafkaProducerService.java
+++ b/src/main/java/cl/atromilen/springkafkaproducer/service/KafkaProducerService.java
@@ -1,0 +1,50 @@
+package cl.atromilen.springkafkaproducer.service;
+
+import cl.atromilen.springkafkaproducer.config.ConfigProperties;
+import cl.atromilen.springkafkaproducer.event.Event;
+import cl.atromilen.springkafkaproducer.event.MessageForEmailing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+public class KafkaProducerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProducerService.class);
+
+    private final KafkaTemplate<String, Event<?>> kafkaTemplate;
+    private final ConfigProperties properties;
+
+    public KafkaProducerService(KafkaTemplate<String, Event<?>> kafkaTemplate, ConfigProperties properties) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.properties = properties;
+    }
+
+    public void send(MessageForEmailing message) throws RuntimeException{
+        Event<MessageForEmailing> event = new Event<>();
+        event.setData(message);
+
+        var key = "msg-" + UUID.randomUUID();
+
+        kafkaTemplate
+                .send(properties.getTopicName(), key, event)
+                .addCallback(this::onSuccess, this::onFailure);
+    }
+
+    private void onSuccess(SendResult<String, Event<?>> result) {
+        LOGGER.info("Message has been written successfully to topic {} into partition {} with key {}.",
+                result.getRecordMetadata().topic(),
+                result.getRecordMetadata().partition(),
+                result.getProducerRecord().key());
+    }
+
+    private void onFailure(Throwable ex) {
+        LOGGER.error("Failure sending message to Kafka topic {}", properties.getTopicName(), ex);
+        throw new RuntimeException(ex.getMessage(), ex);
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,19 @@
+{
+  "properties": [
+    {
+    "name": "spring.kafka.topic-name",
+    "type": "java.lang.String",
+    "description": "(Custom property) Name for topic to create when app starts to running."
+    },
+    {
+      "name": "spring.kafka.topic-partitions",
+      "type": "java.lang.String",
+      "description": "(Custom property) Number of partitions to set for this topic."
+    },
+    {
+      "name": "spring.kafka.topic-replicas",
+      "type": "java.lang.String",
+      "description": "(Custom property) Number of replicas to set for this topic."
+    }
+  ]
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,8 +1,6 @@
 spring:
     kafka:
       bootstrap-servers: localhost:29092
-      topic-name: messages-for-emailing
+      topic-name: embedded-test-topic
       topic-partitions: 1
       topic-replicas: 1
-server:
-  port: 8081

--- a/src/test/java/cl/atromilen/springkafkaproducer/integratedtests/KafkaProducerServiceTest.java
+++ b/src/test/java/cl/atromilen/springkafkaproducer/integratedtests/KafkaProducerServiceTest.java
@@ -1,0 +1,36 @@
+package cl.atromilen.springkafkaproducer.integratedtests;
+
+import cl.atromilen.springkafkaproducer.event.MessageForEmailing;
+import cl.atromilen.springkafkaproducer.service.KafkaProducerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@SpringBootTest
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, brokerProperties = {"listeners=PLAINTEXT://localhost:29092", "port:29092"})
+@ActiveProfiles("test")
+class KafkaProducerServiceTest {
+
+    @Autowired
+    private KafkaProducerService producer;
+
+    @Test
+    void whenAMessageIsProducedWithSuccess_inKafkaProducerService_thenProcessFinishNormally() throws InterruptedException {
+        var messageToSend = getMessageForEmailing();
+        assertDoesNotThrow(() -> producer.send(getMessageForEmailing()));
+    }
+
+    private MessageForEmailing getMessageForEmailing() {
+        MessageForEmailing message = new MessageForEmailing();
+        message.setEmail("mockemail@mock.mock");
+        message.setMessageBody("A mock message body");
+        return message;
+    }
+
+}


### PR DESCRIPTION
- Added Controller to receive message and Service for sending to Kafka.
- Added config for Kafka Producer. Properties handling outsourced to ConfigProperties for reuse purposes.
- Added Event as Wrapper of MessageForEmailing, both representing the message structure to send.
- Added metadata to properties hint showing in IDE as documentation.
- Added Integrated Test representing the happy path for service layer
- Minor change in applicaton.yml. Added test profile to use in test scope.